### PR TITLE
fix: chatbot delay removed limit

### DIFF
--- a/tybotRoute/tiledeskChatbotPlugs/DirectivesChatbotPlug.js
+++ b/tybotRoute/tiledeskChatbotPlugs/DirectivesChatbotPlug.js
@@ -261,6 +261,7 @@ class DirectivesChatbotPlug {
       [Directives.REPLACE_BOT_V2]: DirReplaceBotV2,
       [Directives.REPLACE_BOT_V3]: DirReplaceBotV3,
       [Directives.WAIT]: DirWait,
+      [Directives.WAIT_VARIABLE]: DirWait,
       [Directives.LOCK_INTENT]: DirLockIntent,
       [Directives.UNLOCK_INTENT]: DirUnlockIntent,
       [Directives.FIRE_TILEDESK_EVENT]: DirFireTiledeskEvent,

--- a/tybotRoute/tiledeskChatbotPlugs/directives/DirReply.js
+++ b/tybotRoute/tiledeskChatbotPlugs/directives/DirReply.js
@@ -173,7 +173,7 @@ class DirReply {
         }
         winston.verbose("DirReply reply message sent")
         const delay = TiledeskChatbotUtil.totalMessageWait(cleanMessage);
-        if (delay > 0 && delay <= 30000) { // prevent long delays
+        if (delay > 0) {
           setTimeout(() => {
             callback();
           }, delay);

--- a/tybotRoute/tiledeskChatbotPlugs/directives/DirReplyV2.js
+++ b/tybotRoute/tiledeskChatbotPlugs/directives/DirReplyV2.js
@@ -256,7 +256,7 @@ class DirReplyV2 {
         }
         winston.debug("(DirReplyV2) Reply message sent");
         const delay = TiledeskChatbotUtil.totalMessageWait(cleanMessage);
-        if (delay > 0 && delay <= 30000) { // prevent long delays
+        if (delay > 0) { // prevent long delays
           winston.debug("(DirReplyV2) start timeout callback(" + must_stop + ") for:", current);
           setTimeout(async () => {
             winston.debug("(DirReplyV2) callback(" + must_stop + ") after delay", current);

--- a/tybotRoute/tiledeskChatbotPlugs/directives/DirWait.js
+++ b/tybotRoute/tiledeskChatbotPlugs/directives/DirWait.js
@@ -17,7 +17,7 @@ class DirWait {
     this.logger = new Logger({ request_id: this.requestId, dev: this.context.supportRequest?.draft, intent_id: this.context.reply?.intent_id || this.context.reply?.attributes?.intent_info?.intent_id });
   }
 
-  execute(directive, callback) {
+  async execute(directive, callback) {
     //  500ms < wait-time < 10.000ms
     winston.verbose("Execute Wait directive");
     let action;
@@ -26,15 +26,9 @@ class DirWait {
     }
     else if (directive.parameter) {
       let millis = 500;
-      const _millis = parseInt(directive.parameter.trim());
-      if (!Number.isNaN(millis)) {
+      const _millis = parseInt(directive.parameter.trim(), 10);
+      if (!Number.isNaN(_millis)) {
         millis = _millis;
-      }
-      if (millis > 20000) {
-        millis = 20000
-      }
-      else if (millis < 1000) {
-        millis = 1000
       }
       action = {
         millis: millis
@@ -46,10 +40,70 @@ class DirWait {
       }
     }
 
+    action.millis = await this.resolveMillis(action);
     this.go(action, () => {
       this.logger.native("[Wait] Executed");
       callback();
     })
+  }
+
+  async resolveMillis(action) {
+    if (!action) {
+      return 1000;
+    }
+
+    let millis = action.millis;
+    if (millis && typeof millis === 'object') {
+      const value = millis.value;
+      if (millis.isVariable) {
+        const resolved = await this.resolveVariableValue(value);
+        return this.normalizeMillis(resolved);
+      }
+      return this.normalizeMillis(value);
+    }
+
+    if (typeof millis === 'string') {
+      const parsed = this.parseMillis(millis);
+      if (parsed !== null) {
+        return this.normalizeMillis(parsed);
+      }
+      const resolved = await this.resolveVariableValue(millis);
+      return this.normalizeMillis(resolved);
+    }
+
+    return this.normalizeMillis(millis);
+  }
+
+  async resolveVariableValue(raw) {
+    if (!raw) {
+      return null;
+    }
+    let name = String(raw).trim();
+    const match = name.match(/^\{\{\s*([^}]+)\s*\}\}$/);
+    if (match && match[1]) {
+      name = match[1].trim();
+    }
+    return await this.chatbot.getParameter(name);
+  }
+
+  parseMillis(value) {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      return null;
+    }
+    return parsed;
+  }
+
+  normalizeMillis(value) {
+    const parsed = this.parseMillis(value);
+    let millis = parsed === null ? 1000 : parsed;
+    if (millis > 20000) {
+      millis = 20000;
+    }
+    else if (millis < 1000) {
+      millis = 1000;
+    }
+    return millis;
   }
 
   async go(action, callback) {

--- a/tybotRoute/tiledeskChatbotPlugs/directives/DirWait.js
+++ b/tybotRoute/tiledeskChatbotPlugs/directives/DirWait.js
@@ -97,11 +97,8 @@ class DirWait {
   normalizeMillis(value) {
     const parsed = this.parseMillis(value);
     let millis = parsed === null ? 1000 : parsed;
-    if (millis > 20000) {
-      millis = 20000;
-    }
-    else if (millis < 1000) {
-      millis = 1000;
+    if (millis < 100) {
+      millis = 100;
     }
     return millis;
   }

--- a/tybotRoute/tiledeskChatbotPlugs/directives/Directives.js
+++ b/tybotRoute/tiledeskChatbotPlugs/directives/Directives.js
@@ -10,6 +10,7 @@ class Directives {
   static ASSIGN = "assign"; // DEPRECATED
   static ASK_HELP_CENTER = "askhelpcenter";
   static WAIT = "wait";
+  static WAIT_VARIABLE = "wait_variable";
   static LOCK_INTENT = "lockintent";
   static UNLOCK_INTENT = "unlockintent";
   static FIRE_TILEDESK_EVENT = "firetiledeskevent";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes message and directive timing behavior by removing the 30s cap on reply delays and introducing variable-resolved waits; this can affect conversation pacing and step-reset behavior if misconfigured or if variables resolve unexpectedly.
> 
> **Overview**
> Removes the 30-second upper limit on delayed callbacks after `reply`/`replyv2` messages, allowing `totalMessageWait()` to delay for its full computed duration.
> 
> Adds a new `wait_variable` directive (handled by `DirWait`) and extends `DirWait` to resolve `millis` from strings, `{{var}}` placeholders, or `{ value, isVariable }` objects, then normalize the result to the existing 1s–20s bounds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1be40ddcdd68cf967a4cdd5f43b5050023a2abb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->